### PR TITLE
Remove console logging from contact form submission

### DIFF
--- a/src/components/ContactSection.js
+++ b/src/components/ContactSection.js
@@ -18,8 +18,6 @@ function ContactSection(props) {
     // Show pending indicator
     setPending(true);
 
-    console.log(data);
-
     contact
       .submit(data)
       .then(() => {


### PR DESCRIPTION
## Summary
- remove the debug console log from the contact form submission handler to avoid exposing user data in logs

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f9967931888331998e466e1e788666